### PR TITLE
Fix Radarr quality profile lookup

### DIFF
--- a/radarr/client.go
+++ b/radarr/client.go
@@ -106,7 +106,7 @@ func (c *Client) GetFolders() ([]Folder, error) {
 
 func (c *Client) GetProfile(prfl string) ([]Profile, error) {
 
-	resp, err := c.client.R().SetResult([]Profile{}).Get(prfl)
+	resp, err := c.client.R().SetResult([]Profile{}).Get("qualityprofile")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The existing endpoint the Radarr client is configured to use is legacy and has been removed. This PR changes the client to use the new endpoint.

Fixes #5